### PR TITLE
Change homepage background to white

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,15 +26,15 @@ const pillarsData = [
 
 export default function Page() {
   return (
-    <div className="flex overflow-hidden flex-col pt-0 pb-20 bg-black">
+    <div className="flex overflow-hidden flex-col pt-0 pb-20 bg-white">
       <Hero backgroundImage="/home-hero.jpeg" />
       <Mission text="We, the brothers of the Asian American Brotherhood, have united ourselves in order to forge a stronger sense of unity among Asian Americans in our community and to foster solidarity without coercion. In promoting understanding and bonds across ethnic lines, the Asian American Brotherhood seeks to empower both our members and the communities that we serve." />
 
-      <div className="gap-2.5 self-start py-2.5 pr-16 pl-14 mt-32 text-8xl text-white max-md:px-10 max-md:mt-10 max-md:max-w-full max-md:text-6xl">
+      <div className="gap-2.5 self-start py-2.5 pr-16 pl-14 mt-32 text-8xl text-black max-md:px-10 max-md:mt-10 max-md:max-w-full max-md:text-6xl">
         Three Pillars
       </div>
 
-      <div className="flex flex-col mt-7 w-full text-white max-md:mt-0 max-md:max-w-full">
+      <div className="flex flex-col mt-7 w-full text-black max-md:mt-0 max-md:max-w-full">
         {pillarsData.map((pillar, index) => (
           <Pillar
             key={index}

--- a/src/app/ui/homepage/ActionButton.tsx
+++ b/src/app/ui/homepage/ActionButton.tsx
@@ -10,10 +10,10 @@ export const ActionButton: React.FC<ActionButtonProps & { link: string }> = ({
 }) => (
   <Link
     href={link}
-    className="flex flex-col justify-center px-3 py-2 border border-solid border-stone-700 rounded-[40px] hover:bg-stone-800 transition"
+    className="flex flex-col justify-center px-3 py-2 border border-solid border-stone-700 rounded-[40px] hover:bg-stone-200 transition"
   >
     <div className="flex gap-4 justify-center items-center px-2">
-      <div className="self-stretch my-auto text-xl text-white">{text}</div>
+      <div className="self-stretch my-auto text-xl text-black">{text}</div>
       <div className="flex flex-col justify-center items-center self-stretch pr-2.5 pl-2.5 my-auto w-9 h-9 bg-red-800 rounded-2xl min-h-[36px]">
         <Image
           src={icon}

--- a/src/app/ui/homepage/Mission.tsx
+++ b/src/app/ui/homepage/Mission.tsx
@@ -4,7 +4,7 @@ import { ActionButton } from "./ActionButton";
 
 export const Mission: React.FC<MissionProps> = ({ text }) => (
   <div className="flex flex-wrap gap-12 items-start px-16 mt-32 max-w-full w-[822px] max-md:px-5 max-md:mt-10">
-    <div className="grow shrink gap-2.5 self-stretch py-2.5 text-4xl text-white min-w-[240px] w-[659px] max-md:px-5 max-md:max-w-full">
+    <div className="grow shrink gap-2.5 self-stretch py-2.5 text-4xl text-black min-w-[240px] w-[659px] max-md:px-5 max-md:max-w-full">
       {text}
     </div>
     <ActionButton


### PR DESCRIPTION
# Change homepage background to white

## Summary
Changed the homepage background from black to white and updated all text colors for proper contrast and readability. This addresses issue #4.

**Changes:**
- Updated main page container background from `bg-black` to `bg-white`
- Changed "Three Pillars" heading text from `text-white` to `text-black`
- Updated Mission statement text color from `text-white` to `text-black`
- Changed ActionButton text from `text-white` to `text-black`
- Updated ActionButton hover state from `hover:bg-stone-800` to `hover:bg-stone-200` for better visibility on white background

**Note:** Hero and Pillar components retain their background images with dark overlays and white text, which should still provide good contrast.

## Review & Testing Checklist for Human
- [ ] **Visual verification**: View the homepage at http://localhost:3000 to ensure all elements look correct on the white background
- [ ] **Contrast check**: Verify that all text (especially "Three Pillars" heading, mission statement, and button text) has sufficient contrast for accessibility
- [ ] **Button hover states**: Test hovering over the "CONSTITUTION" and "BROTHERS" buttons to ensure the light gray hover effect (`hover:bg-stone-200`) looks appropriate
- [ ] **Hero and Pillar sections**: Scroll through the page to verify that the Hero section and Three Pillars sections (Service, Brotherhood, Activism) still look good with their background images and white text overlays
- [ ] **Responsive design**: Test on mobile/tablet viewports to ensure the white background works well at all screen sizes

### Notes
- Only the homepage was modified. Other pages (brothers, recruits, etc.) still use black backgrounds, which may create an inconsistent experience across the site
- Lint checks passed successfully

---
**Link to Devin run:** https://app.devin.ai/sessions/5bb2b6b8a5ef4762af840ad3b29eccba  
**Requested by:** mvu@college.harvard.edu (@mmattyV)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch homepage to a white background and update key text and button hover colors for proper contrast.
> 
> - **UI (Homepage)**:
>   - Set main container background to `bg-white` in `src/app/page.tsx`.
>   - Update text colors to `text-black` for "Three Pillars" heading and page content containers.
>   - Adjust `Mission` text color to `text-black` in `src/app/ui/homepage/Mission.tsx`.
>   - Update `ActionButton` in `src/app/ui/homepage/ActionButton.tsx`:
>     - Change text color to `text-black`.
>     - Change hover state to `hover:bg-stone-200` (from `hover:bg-stone-800`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9367afc582768899869b34294325a071765d1dcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->