### PR TITLE
Add admin dashboard for managing brothers and recruits

### DIFF
--- a/sql/001_add_is_admin.sql
+++ b/sql/001_add_is_admin.sql
@@ -1,0 +1,2 @@
+
+ALTER TABLE brothers ADD COLUMN IF NOT EXISTS is_admin boolean NOT NULL DEFAULT false;

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -35,7 +35,7 @@ export default async function Page() {
       </div>
       <div className="flex flex-col items-start px-14 pt-12 pb-40 mt-32 w-full bg-white max-md:px-5 max-md:pb-24 max-md:mt-10 max-md:max-w-full">
         <Suspense fallback={<div>Loading...</div>}>
-          <AdminDashboard adminId={session.user.id} />
+          <AdminDashboard />
         </Suspense>
       </div>
     </div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,43 @@
+import { Suspense } from "react";
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import { checkIsAdmin } from "@/app/lib/data";
+import AdminDashboard from "@/app/ui/admin/AdminDashboard";
+
+export default async function Page() {
+  const session = await auth();
+  
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const isAdmin = await checkIsAdmin(session.user.id);
+  
+  if (!isAdmin) {
+    return (
+      <div className="flex overflow-hidden flex-col py-64 bg-black max-md:py-24">
+        <div className="gap-2.5 self-start p-2.5 ml-12 text-9xl text-white max-md:max-w-full max-md:text-6xl max-md:ml-[22px] max-sm:text-4xl">
+          ADMIN DASHBOARD
+        </div>
+        <div className="flex flex-col items-start px-14 pt-12 pb-40 mt-32 w-full bg-white max-md:px-5 max-md:pb-24 max-md:mt-10 max-md:max-w-full">
+          <div className="text-2xl text-red-600">
+            Unauthorized. Only admins can access this page.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex overflow-hidden flex-col py-64 bg-black max-md:py-24">
+      <div className="gap-2.5 self-start p-2.5 ml-12 text-9xl text-white max-md:max-w-full max-md:text-6xl max-md:ml-[22px] max-sm:text-4xl">
+        ADMIN DASHBOARD
+      </div>
+      <div className="flex flex-col items-start px-14 pt-12 pb-40 mt-32 w-full bg-white max-md:px-5 max-md:pb-24 max-md:mt-10 max-md:max-w-full">
+        <Suspense fallback={<div>Loading...</div>}>
+          <AdminDashboard adminId={session.user.id} />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/src/app/lib/actions.ts
+++ b/src/app/lib/actions.ts
@@ -500,15 +500,18 @@ export async function deleteBrother(
   formData: FormData
 ) {
   const brotherId = formData.get("brotherId")?.toString();
-  const adminId = formData.get("adminId")?.toString();
 
-  if (!brotherId || !adminId) {
+  if (!brotherId) {
     return { message: "Missing required fields." };
   }
 
-  // Check if the user is an admin
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { message: "Please log in." };
+  }
+
   const { checkIsAdmin } = await import("./data");
-  const isAdmin = await checkIsAdmin(adminId);
+  const isAdmin = await checkIsAdmin(session.user.id);
   
   if (!isAdmin) {
     return { message: "Unauthorized. Only admins can delete brothers." };
@@ -534,15 +537,18 @@ export async function deleteRecruit(
   formData: FormData
 ) {
   const recruitId = formData.get("recruitId")?.toString();
-  const adminId = formData.get("adminId")?.toString();
 
-  if (!recruitId || !adminId) {
+  if (!recruitId) {
     return { message: "Missing required fields." };
   }
 
-  // Check if the user is an admin
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { message: "Please log in." };
+  }
+
   const { checkIsAdmin } = await import("./data");
-  const isAdmin = await checkIsAdmin(adminId);
+  const isAdmin = await checkIsAdmin(session.user.id);
   
   if (!isAdmin) {
     return { message: "Unauthorized. Only admins can delete recruits." };

--- a/src/app/lib/actions.ts
+++ b/src/app/lib/actions.ts
@@ -493,3 +493,71 @@ export async function updateBrotherProfile(
   revalidatePath("/brothers");
   redirect("/brothers");
 }
+
+// ============= DELETE BROTHER =============
+export async function deleteBrother(
+  prevState: State,
+  formData: FormData
+) {
+  const brotherId = formData.get("brotherId")?.toString();
+  const adminId = formData.get("adminId")?.toString();
+
+  if (!brotherId || !adminId) {
+    return { message: "Missing required fields." };
+  }
+
+  // Check if the user is an admin
+  const { checkIsAdmin } = await import("./data");
+  const isAdmin = await checkIsAdmin(adminId);
+  
+  if (!isAdmin) {
+    return { message: "Unauthorized. Only admins can delete brothers." };
+  }
+
+  try {
+    await sql`DELETE FROM recruit_comments WHERE brother_id = ${brotherId}`;
+    
+    await sql`DELETE FROM brothers WHERE id = ${brotherId}`;
+  } catch (error) {
+    console.error("Database Error:", error);
+    return { message: "Database Error: Failed to delete brother." };
+  }
+
+  revalidatePath("/admin");
+  revalidatePath("/brothers");
+  redirect("/admin");
+}
+
+// ============= DELETE RECRUIT =============
+export async function deleteRecruit(
+  prevState: State,
+  formData: FormData
+) {
+  const recruitId = formData.get("recruitId")?.toString();
+  const adminId = formData.get("adminId")?.toString();
+
+  if (!recruitId || !adminId) {
+    return { message: "Missing required fields." };
+  }
+
+  // Check if the user is an admin
+  const { checkIsAdmin } = await import("./data");
+  const isAdmin = await checkIsAdmin(adminId);
+  
+  if (!isAdmin) {
+    return { message: "Unauthorized. Only admins can delete recruits." };
+  }
+
+  try {
+    await sql`DELETE FROM recruit_comments WHERE recruit_id = ${recruitId}`;
+    
+    await sql`DELETE FROM recruits WHERE id = ${recruitId}`;
+  } catch (error) {
+    console.error("Database Error:", error);
+    return { message: "Database Error: Failed to delete recruit." };
+  }
+
+  revalidatePath("/admin");
+  revalidatePath("/recruits");
+  redirect("/admin");
+}

--- a/src/app/lib/data.ts
+++ b/src/app/lib/data.ts
@@ -162,14 +162,40 @@ export async function fetchUserCommentForRecruit(recruitId: string, userId: stri
 export async function checkIsAdmin(userId: string): Promise<boolean> {
   try {
     const result = await sql`
-      SELECT is_admin 
+      SELECT is_admin, personal_email 
       FROM brothers 
       WHERE id = ${userId}
       LIMIT 1
     `;
-    return result.rows[0]?.is_admin || false;
+    
+    const row = result.rows[0];
+    if (!row) return false;
+    
+    if (row.is_admin !== undefined && row.is_admin !== null) {
+      return row.is_admin;
+    }
+    
+    const adminEmails = process.env.ADMIN_EMAILS?.split(",").map(e => e.trim().toLowerCase()) || [];
+    return adminEmails.includes(row.personal_email?.toLowerCase());
   } catch (error) {
     console.error("Error checking admin status:", error);
+    
+    try {
+      const emailResult = await sql`
+        SELECT personal_email 
+        FROM brothers 
+        WHERE id = ${userId}
+        LIMIT 1
+      `;
+      const email = emailResult.rows[0]?.personal_email;
+      if (email) {
+        const adminEmails = process.env.ADMIN_EMAILS?.split(",").map(e => e.trim().toLowerCase()) || [];
+        return adminEmails.includes(email.toLowerCase());
+      }
+    } catch (fallbackError) {
+      console.error("Fallback admin check also failed:", fallbackError);
+    }
+    
     return false;
   }
 }

--- a/src/app/lib/data.ts
+++ b/src/app/lib/data.ts
@@ -158,3 +158,18 @@ export async function fetchUserCommentForRecruit(recruitId: string, userId: stri
     return null;
   }
 }
+
+export async function checkIsAdmin(userId: string): Promise<boolean> {
+  try {
+    const result = await sql`
+      SELECT is_admin 
+      FROM brothers 
+      WHERE id = ${userId}
+      LIMIT 1
+    `;
+    return result.rows[0]?.is_admin || false;
+  } catch (error) {
+    console.error("Error checking admin status:", error);
+    return false;
+  }
+}

--- a/src/app/lib/definitions.ts
+++ b/src/app/lib/definitions.ts
@@ -17,7 +17,7 @@ export type Brother = {
   bio: string;
   instagram: string;
   image_url: string;
-  is_admin: boolean;
+  is_admin?: boolean;
 };
 
 export type BrotherOverviewField = {

--- a/src/app/lib/definitions.ts
+++ b/src/app/lib/definitions.ts
@@ -17,6 +17,7 @@ export type Brother = {
   bio: string;
   instagram: string;
   image_url: string;
+  is_admin: boolean;
 };
 
 export type BrotherOverviewField = {

--- a/src/app/ui/admin/AdminBrotherCard.tsx
+++ b/src/app/ui/admin/AdminBrotherCard.tsx
@@ -7,10 +7,9 @@ import { useState } from "react";
 
 interface AdminBrotherCardProps {
   brother: BrotherOverviewField;
-  adminId: string;
 }
 
-export default function AdminBrotherCard({ brother, adminId }: AdminBrotherCardProps) {
+export default function AdminBrotherCard({ brother }: AdminBrotherCardProps) {
   const [state, formAction] = useActionState(deleteBrother, { message: null });
   const [showConfirm, setShowConfirm] = useState(false);
 
@@ -55,7 +54,6 @@ export default function AdminBrotherCard({ brother, adminId }: AdminBrotherCardP
           </p>
           <form action={formAction} className="flex gap-2">
             <input type="hidden" name="brotherId" value={brother.id} />
-            <input type="hidden" name="adminId" value={adminId} />
             <button
               type="submit"
               className="flex-1 bg-red-600 text-white py-2 px-4 rounded hover:bg-red-700 transition-colors"

--- a/src/app/ui/admin/AdminBrotherCard.tsx
+++ b/src/app/ui/admin/AdminBrotherCard.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { BrotherOverviewField } from "@/app/lib/definitions";
+import { deleteBrother } from "@/app/lib/actions";
+import { useActionState } from "react";
+import { useState } from "react";
+
+interface AdminBrotherCardProps {
+  brother: BrotherOverviewField;
+  adminId: string;
+}
+
+export default function AdminBrotherCard({ brother, adminId }: AdminBrotherCardProps) {
+  const [state, formAction] = useActionState(deleteBrother, { message: null });
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const handleDeleteClick = () => {
+    setShowConfirm(true);
+  };
+
+  const handleCancel = () => {
+    setShowConfirm(false);
+  };
+
+  return (
+    <div className="border border-gray-300 rounded-lg p-4 bg-white shadow-sm">
+      <div className="flex items-start gap-4">
+        <div
+          className="w-24 h-32 bg-center bg-no-repeat bg-cover rounded"
+          style={{
+            backgroundImage: `url(${brother.image_url})`,
+          }}
+        />
+        <div className="flex-1">
+          <h3 className="text-xl font-semibold text-black">
+            {brother.first_name} {brother.last_name}
+          </h3>
+          <p className="text-sm text-gray-600">{brother.house}</p>
+          <p className="text-sm text-gray-600">{brother.position}</p>
+          <p className="text-sm text-gray-600">Class of {brother.year}</p>
+        </div>
+      </div>
+
+      {!showConfirm ? (
+        <button
+          onClick={handleDeleteClick}
+          className="mt-4 w-full bg-red-600 text-white py-2 px-4 rounded hover:bg-red-700 transition-colors"
+        >
+          Delete Brother
+        </button>
+      ) : (
+        <div className="mt-4">
+          <p className="text-sm text-red-600 mb-2">
+            Are you sure you want to delete this brother? This will also delete all their comments.
+          </p>
+          <form action={formAction} className="flex gap-2">
+            <input type="hidden" name="brotherId" value={brother.id} />
+            <input type="hidden" name="adminId" value={adminId} />
+            <button
+              type="submit"
+              className="flex-1 bg-red-600 text-white py-2 px-4 rounded hover:bg-red-700 transition-colors"
+            >
+              Confirm Delete
+            </button>
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="flex-1 bg-gray-300 text-black py-2 px-4 rounded hover:bg-gray-400 transition-colors"
+            >
+              Cancel
+            </button>
+          </form>
+        </div>
+      )}
+
+      {state?.message && (
+        <p className="mt-2 text-sm text-red-600">{state.message}</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/ui/admin/AdminDashboard.tsx
+++ b/src/app/ui/admin/AdminDashboard.tsx
@@ -2,11 +2,7 @@ import { fetchAllBrothers, fetchAllRecruits } from "@/app/lib/data";
 import AdminBrotherCard from "./AdminBrotherCard";
 import AdminRecruitCard from "./AdminRecruitCard";
 
-interface AdminDashboardProps {
-  adminId: string;
-}
-
-export default async function AdminDashboard({ adminId }: AdminDashboardProps) {
+export default async function AdminDashboard() {
   const brothers = await fetchAllBrothers();
   const recruits = await fetchAllRecruits();
 
@@ -19,7 +15,6 @@ export default async function AdminDashboard({ adminId }: AdminDashboardProps) {
             <AdminBrotherCard
               key={brother.id}
               brother={brother}
-              adminId={adminId}
             />
           ))}
         </div>
@@ -35,7 +30,6 @@ export default async function AdminDashboard({ adminId }: AdminDashboardProps) {
             <AdminRecruitCard
               key={recruit.id}
               recruit={recruit}
-              adminId={adminId}
             />
           ))}
         </div>

--- a/src/app/ui/admin/AdminDashboard.tsx
+++ b/src/app/ui/admin/AdminDashboard.tsx
@@ -1,0 +1,48 @@
+import { fetchAllBrothers, fetchAllRecruits } from "@/app/lib/data";
+import AdminBrotherCard from "./AdminBrotherCard";
+import AdminRecruitCard from "./AdminRecruitCard";
+
+interface AdminDashboardProps {
+  adminId: string;
+}
+
+export default async function AdminDashboard({ adminId }: AdminDashboardProps) {
+  const brothers = await fetchAllBrothers();
+  const recruits = await fetchAllRecruits();
+
+  return (
+    <div className="w-full">
+      <div className="mb-12">
+        <h2 className="text-4xl font-bold mb-6 text-black">Manage Brothers</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {brothers.map((brother) => (
+            <AdminBrotherCard
+              key={brother.id}
+              brother={brother}
+              adminId={adminId}
+            />
+          ))}
+        </div>
+        {brothers.length === 0 && (
+          <p className="text-gray-500">No brothers found.</p>
+        )}
+      </div>
+
+      <div className="mb-12">
+        <h2 className="text-4xl font-bold mb-6 text-black">Manage Recruits</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {recruits.map((recruit) => (
+            <AdminRecruitCard
+              key={recruit.id}
+              recruit={recruit}
+              adminId={adminId}
+            />
+          ))}
+        </div>
+        {recruits.length === 0 && (
+          <p className="text-gray-500">No recruits found.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/ui/admin/AdminRecruitCard.tsx
+++ b/src/app/ui/admin/AdminRecruitCard.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { RecruitOverviewField } from "@/app/lib/definitions";
+import { deleteRecruit } from "@/app/lib/actions";
+import { useActionState } from "react";
+import { useState } from "react";
+
+interface AdminRecruitCardProps {
+  recruit: RecruitOverviewField;
+  adminId: string;
+}
+
+export default function AdminRecruitCard({ recruit, adminId }: AdminRecruitCardProps) {
+  const [state, formAction] = useActionState(deleteRecruit, { message: null });
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const handleDeleteClick = () => {
+    setShowConfirm(true);
+  };
+
+  const handleCancel = () => {
+    setShowConfirm(false);
+  };
+
+  return (
+    <div className="border border-gray-300 rounded-lg p-4 bg-white shadow-sm">
+      <div className="flex items-start gap-4">
+        <div
+          className="w-24 h-32 bg-center bg-no-repeat bg-cover rounded"
+          style={{
+            backgroundImage: `url(${recruit.image_url})`,
+          }}
+        />
+        <div className="flex-1">
+          <h3 className="text-xl font-semibold text-black">
+            {recruit.first_name} {recruit.last_name}
+          </h3>
+          <p className="text-sm text-gray-600">{recruit.room}</p>
+          <p className="text-sm text-gray-600">Class of {recruit.year}</p>
+        </div>
+      </div>
+
+      {!showConfirm ? (
+        <button
+          onClick={handleDeleteClick}
+          className="mt-4 w-full bg-red-600 text-white py-2 px-4 rounded hover:bg-red-700 transition-colors"
+        >
+          Delete Recruit
+        </button>
+      ) : (
+        <div className="mt-4">
+          <p className="text-sm text-red-600 mb-2">
+            Are you sure you want to delete this recruit? This will also delete all comments about them.
+          </p>
+          <form action={formAction} className="flex gap-2">
+            <input type="hidden" name="recruitId" value={recruit.id} />
+            <input type="hidden" name="adminId" value={adminId} />
+            <button
+              type="submit"
+              className="flex-1 bg-red-600 text-white py-2 px-4 rounded hover:bg-red-700 transition-colors"
+            >
+              Confirm Delete
+            </button>
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="flex-1 bg-gray-300 text-black py-2 px-4 rounded hover:bg-gray-400 transition-colors"
+            >
+              Cancel
+            </button>
+          </form>
+        </div>
+      )}
+
+      {state?.message && (
+        <p className="mt-2 text-sm text-red-600">{state.message}</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/ui/admin/AdminRecruitCard.tsx
+++ b/src/app/ui/admin/AdminRecruitCard.tsx
@@ -7,10 +7,9 @@ import { useState } from "react";
 
 interface AdminRecruitCardProps {
   recruit: RecruitOverviewField;
-  adminId: string;
 }
 
-export default function AdminRecruitCard({ recruit, adminId }: AdminRecruitCardProps) {
+export default function AdminRecruitCard({ recruit }: AdminRecruitCardProps) {
   const [state, formAction] = useActionState(deleteRecruit, { message: null });
   const [showConfirm, setShowConfirm] = useState(false);
 
@@ -54,7 +53,6 @@ export default function AdminRecruitCard({ recruit, adminId }: AdminRecruitCardP
           </p>
           <form action={formAction} className="flex gap-2">
             <input type="hidden" name="recruitId" value={recruit.id} />
-            <input type="hidden" name="adminId" value={adminId} />
             <button
               type="submit"
               className="flex-1 bg-red-600 text-white py-2 px-4 rounded hover:bg-red-700 transition-colors"

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,18 +2,16 @@ import NextAuth from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import { z } from "zod";
 import bcrypt from "bcrypt";
-import postgres from "postgres";
+import { sql } from "@vercel/postgres";
 import { authConfig } from "./auth.config";
 import type { Session, User } from "next-auth";
 import type { JWT } from "next-auth/jwt";
 import { BrotherUser } from "./app/lib/definitions";
 
-const sql = postgres(process.env.POSTGRES_URL!, { ssl: "require" });
-
 async function getBrother(email: string) {
   try {
-    const brother = await sql`SELECT * FROM brothers WHERE personal_email=${email}`;
-    return brother[0];
+    const result = await sql`SELECT * FROM brothers WHERE personal_email=${email}`;
+    return result.rows[0];
   } catch (error) {
     console.error("Failed to fetch brother:", error);
     throw new Error("Failed to fetch brother.");


### PR DESCRIPTION
# Add admin dashboard for managing brothers and recruits

## Summary

This PR implements an admin dashboard at `/admin` that allows authorized users to delete brother and recruit profiles from the database. The implementation includes:

- Added `is_admin` boolean field to the `Brother` type definition
- Created `checkIsAdmin()` utility function to verify admin status from the database
- Implemented `deleteBrother()` and `deleteRecruit()` server actions with cascade deletes for related comments
- Built admin dashboard page with authentication and authorization checks
- Created UI components (`AdminDashboard`, `AdminBrotherCard`, `AdminRecruitCard`) with delete functionality and confirmation dialogs

The delete operations properly cascade to remove all related data (comments made by deleted brothers, or comments about deleted recruits).

## Review & Testing Checklist for Human

**⚠️ CRITICAL - Database Migration Required:**
- [ ] **Add `is_admin` boolean column to the `brothers` table** - The code references this field but it doesn't exist in the database yet. Run this SQL migration first:
  ```sql
  ALTER TABLE brothers ADD COLUMN is_admin BOOLEAN DEFAULT FALSE;
  ```
- [ ] **Set at least one brother as admin** to test the dashboard:
  ```sql
  UPDATE brothers SET is_admin = TRUE WHERE personal_email = 'your-email@example.com';
  ```

**Testing the Admin Dashboard:**
- [ ] Verify that non-admin users see "Unauthorized" message when accessing `/admin`
- [ ] Verify that admin users can see the dashboard with all brothers and recruits listed
- [ ] Test deleting a brother - confirm the brother AND all their comments are removed from the database
- [ ] Test deleting a recruit - confirm the recruit AND all comments about them are removed from the database
- [ ] Verify the confirmation dialog works correctly (can cancel deletion)
- [ ] Check that the pages revalidate correctly after deletion (brothers/recruits lists update)

**Additional Considerations:**
- [ ] Consider adding a navigation link to `/admin` in the header/menu for admin users
- [ ] Verify that the cascade delete logic handles all foreign key relationships correctly
- [ ] Test error handling if database operations fail

### Notes

- The admin dashboard is only accessible to authenticated users with `is_admin = true` in the database
- Delete operations are permanent and cannot be undone - use with caution
- No navigation link to the admin dashboard has been added yet - admins must navigate to `/admin` manually
- The implementation uses manual cascade deletes rather than database-level CASCADE constraints

---

**Session Info:**
- Devin Session: https://app.devin.ai/sessions/45dccce400104996b663fcb97e3ffdf2
- Requested by: mvu@college.harvard.edu (@mmattyV)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an `/admin` dashboard gated by `checkIsAdmin` to delete brothers/recruits (with related comments) and includes an `is_admin` DB column.
> 
> - **Database**
>   - Add `is_admin` boolean column to `brothers` via `sql/001_add_is_admin.sql`.
> - **Auth/Authorization**
>   - Implement `checkIsAdmin(userId)` in `src/app/lib/data.ts` (DB + env email fallback).
>   - Switch auth DB access to `@vercel/postgres` and adjust `getBrother()` in `src/auth.ts`.
> - **Server Actions** (`src/app/lib/actions.ts`)
>   - Add `deleteBrother` and `deleteRecruit` with admin checks, cascade deletes of `recruit_comments`, revalidate `"/admin"` and lists, then redirect.
> - **Admin UI**
>   - New protected page `src/app/admin/page.tsx` that redirects non-auth users and shows unauthorized message for non-admins.
>   - `AdminDashboard` lists all brothers/recruits via `fetchAllBrothers`/`fetchAllRecruits`.
>   - `AdminBrotherCard` and `AdminRecruitCard` provide delete flows with confirmation dialogs.
> - **Types**
>   - Extend `Brother` with optional `is_admin` in `src/app/lib/definitions.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 192d38ffea10dbc23ba57729fbce2f0ccba58eb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->