### PR TITLE
Add admin dashboard with delete functionality and authorization

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,42 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import { fetchAllBrothers, fetchAllRecruits } from "@/app/lib/data";
+import AdminDashboard from "@/app/ui/admin/AdminDashboard";
+
+export default async function AdminPage() {
+  const session = await auth();
+  
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+  
+  if (!session.user.isAdmin) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-red-600 mb-4">Access Denied</h1>
+          <p className="text-gray-600">You do not have permission to access this page.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const brothers = await fetchAllBrothers();
+  const recruits = await fetchAllRecruits();
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">Admin Dashboard</h1>
+          <p className="mt-2 text-gray-600">Manage brothers and recruits</p>
+        </div>
+        <AdminDashboard 
+          brothers={brothers} 
+          recruits={recruits}
+          adminId={session.user.id}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/lib/actions.ts
+++ b/src/app/lib/actions.ts
@@ -493,3 +493,117 @@ export async function updateBrotherProfile(
   revalidatePath("/brothers");
   redirect("/brothers");
 }
+
+// ============= ADMIN: DELETE BROTHER =============
+export async function deleteBrother(
+  brotherId: string,
+  adminId: string
+): Promise<{ success: boolean; message: string }> {
+  try {
+    const adminResult = await sql`
+      SELECT is_admin FROM brothers WHERE id = ${adminId}
+    `;
+    
+    if (!adminResult.rows[0]?.is_admin) {
+      return { success: false, message: "Unauthorized: Admin access required." };
+    }
+
+    const adminCount = await sql`
+      SELECT COUNT(*) as count FROM brothers WHERE is_admin = TRUE
+    `;
+    
+    const targetBrother = await sql`
+      SELECT is_admin, image_url FROM brothers WHERE id = ${brotherId}
+    `;
+    
+    if (!targetBrother.rows[0]) {
+      return { success: false, message: "Brother not found." };
+    }
+    
+    if (targetBrother.rows[0].is_admin && parseInt(adminCount.rows[0].count) <= 1) {
+      return { success: false, message: "Cannot delete the last admin." };
+    }
+
+    await sql`
+      DELETE FROM recruit_comments WHERE brother_id = ${brotherId}
+    `;
+
+    await sql`
+      DELETE FROM brothers WHERE id = ${brotherId}
+    `;
+
+    const imageUrl = targetBrother.rows[0].image_url;
+    if (imageUrl) {
+      try {
+        const { del } = await import("@vercel/blob");
+        await del(imageUrl);
+      } catch (blobError) {
+        console.error("Failed to delete blob:", blobError);
+      }
+    }
+
+    console.log(`[AUDIT] Brother ${brotherId} deleted by admin ${adminId} at ${new Date().toISOString()}`);
+
+    revalidatePath("/brothers");
+    revalidatePath("/admin");
+    revalidatePath(`/brothers/${brotherId}/details`);
+
+    return { success: true, message: "Brother deleted successfully." };
+  } catch (error) {
+    console.error("Error deleting brother:", error);
+    return { success: false, message: "Failed to delete brother." };
+  }
+}
+
+// ============= ADMIN: DELETE RECRUIT =============
+export async function deleteRecruit(
+  recruitId: string,
+  adminId: string
+): Promise<{ success: boolean; message: string }> {
+  try {
+    const adminResult = await sql`
+      SELECT is_admin FROM brothers WHERE id = ${adminId}
+    `;
+    
+    if (!adminResult.rows[0]?.is_admin) {
+      return { success: false, message: "Unauthorized: Admin access required." };
+    }
+
+    const targetRecruit = await sql`
+      SELECT image_url FROM recruits WHERE id = ${recruitId}
+    `;
+    
+    if (!targetRecruit.rows[0]) {
+      return { success: false, message: "Recruit not found." };
+    }
+
+    await sql`
+      DELETE FROM recruit_comments WHERE recruit_id = ${recruitId}
+    `;
+
+    await sql`
+      DELETE FROM recruits WHERE id = ${recruitId}
+    `;
+
+    const imageUrl = targetRecruit.rows[0].image_url;
+    if (imageUrl) {
+      try {
+        const { del } = await import("@vercel/blob");
+        await del(imageUrl);
+      } catch (blobError) {
+        console.error("Failed to delete blob:", blobError);
+      }
+    }
+
+    console.log(`[AUDIT] Recruit ${recruitId} deleted by admin ${adminId} at ${new Date().toISOString()}`);
+
+    revalidatePath("/_recruits");
+    revalidatePath("/admin");
+    revalidatePath(`/_recruits/${recruitId}/details`);
+
+    return { success: true, message: "Recruit deleted successfully." };
+  } catch (error) {
+    console.error("Error deleting recruit:", error);
+    return { success: false, message: "Failed to delete recruit." };
+  }
+}

--- a/src/app/lib/definitions.ts
+++ b/src/app/lib/definitions.ts
@@ -17,6 +17,7 @@ export type Brother = {
   bio: string;
   instagram: string;
   image_url: string;
+  is_admin: boolean;
 };
 
 export type BrotherOverviewField = {
@@ -186,5 +187,6 @@ export interface BrotherUser {
   id: string;
   personal_email: string;
   password: string;
+  is_admin: boolean;
   // any other fields from your DB
 }

--- a/src/app/ui/admin/AdminDashboard.tsx
+++ b/src/app/ui/admin/AdminDashboard.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { BrotherOverviewField, RecruitOverviewField } from "@/app/lib/definitions";
+import BrothersTable from "./BrothersTable";
+import RecruitsTable from "./RecruitsTable";
+
+interface AdminDashboardProps {
+  brothers: BrotherOverviewField[];
+  recruits: RecruitOverviewField[];
+  adminId: string;
+}
+
+export default function AdminDashboard({ brothers, recruits, adminId }: AdminDashboardProps) {
+  const [activeTab, setActiveTab] = useState<"brothers" | "recruits">("brothers");
+
+  return (
+    <div>
+      <div className="border-b border-gray-200 mb-6">
+        <nav className="-mb-px flex space-x-8">
+          <button
+            onClick={() => setActiveTab("brothers")}
+            className={`${
+              activeTab === "brothers"
+                ? "border-blue-500 text-blue-600"
+                : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+            } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}
+          >
+            Brothers ({brothers.length})
+          </button>
+          <button
+            onClick={() => setActiveTab("recruits")}
+            className={`${
+              activeTab === "recruits"
+                ? "border-blue-500 text-blue-600"
+                : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+            } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}
+          >
+            Recruits ({recruits.length})
+          </button>
+        </nav>
+      </div>
+
+      {activeTab === "brothers" ? (
+        <BrothersTable brothers={brothers} adminId={adminId} />
+      ) : (
+        <RecruitsTable recruits={recruits} adminId={adminId} />
+      )}
+    </div>
+  );
+}

--- a/src/app/ui/admin/BrothersTable.tsx
+++ b/src/app/ui/admin/BrothersTable.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState } from "react";
+import { BrotherOverviewField } from "@/app/lib/definitions";
+import { deleteBrother } from "@/app/lib/actions";
+import { useRouter } from "next/navigation";
+import DeleteConfirmationModal from "./DeleteConfirmationModal";
+
+interface BrothersTableProps {
+  brothers: BrotherOverviewField[];
+  adminId: string;
+}
+
+export default function BrothersTable({ brothers, adminId }: BrothersTableProps) {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const filteredBrothers = brothers.filter((brother) => {
+    const searchLower = searchTerm.toLowerCase();
+    return (
+      brother.first_name.toLowerCase().includes(searchLower) ||
+      brother.last_name.toLowerCase().includes(searchLower) ||
+      brother.house.toLowerCase().includes(searchLower) ||
+      brother.position.toLowerCase().includes(searchLower)
+    );
+  });
+
+  const handleDeleteClick = (brother: BrotherOverviewField) => {
+    setDeleteTarget({
+      id: brother.id,
+      name: `${brother.first_name} ${brother.last_name}`,
+    });
+    setError(null);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!deleteTarget) return;
+
+    setIsDeleting(true);
+    setError(null);
+
+    try {
+      const result = await deleteBrother(deleteTarget.id, adminId);
+      
+      if (result.success) {
+        setDeleteTarget(null);
+        router.refresh();
+      } else {
+        setError(result.message);
+      }
+    } catch {
+      setError("An unexpected error occurred.");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleCancelDelete = () => {
+    setDeleteTarget(null);
+    setError(null);
+  };
+
+  return (
+    <div>
+      <div className="mb-4">
+        <input
+          type="text"
+          placeholder="Search brothers by name, house, or position..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        />
+      </div>
+
+      <div className="bg-white shadow-md rounded-lg overflow-hidden">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Name
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                House
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Position
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Year
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {filteredBrothers.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-6 py-4 text-center text-gray-500">
+                  No brothers found
+                </td>
+              </tr>
+            ) : (
+              filteredBrothers.map((brother) => (
+                <tr key={brother.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <div className="flex items-center">
+                      <div className="h-10 w-10 flex-shrink-0">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          className="h-10 w-10 rounded-full object-cover"
+                          src={brother.image_url}
+                          alt={`${brother.first_name} ${brother.last_name}`}
+                        />
+                      </div>
+                      <div className="ml-4">
+                        <div className="text-sm font-medium text-gray-900">
+                          {brother.first_name} {brother.last_name}
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {brother.house}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {brother.position}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {brother.year}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                    <button
+                      onClick={() => handleDeleteClick(brother)}
+                      className="text-red-600 hover:text-red-900 transition-colors"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {deleteTarget && (
+        <DeleteConfirmationModal
+          title="Delete Brother"
+          message={`Are you sure you want to delete ${deleteTarget.name}? This action cannot be undone and will also delete all associated comments.`}
+          onConfirm={handleConfirmDelete}
+          onCancel={handleCancelDelete}
+          isDeleting={isDeleting}
+          error={error}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/ui/admin/DeleteConfirmationModal.tsx
+++ b/src/app/ui/admin/DeleteConfirmationModal.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+interface DeleteConfirmationModalProps {
+  title: string;
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isDeleting: boolean;
+  error: string | null;
+}
+
+export default function DeleteConfirmationModal({
+  title,
+  message,
+  onConfirm,
+  onCancel,
+  isDeleting,
+  error,
+}: DeleteConfirmationModalProps) {
+  return (
+    <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50 flex items-center justify-center">
+      <div className="relative bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
+        <div className="p-6">
+          <h3 className="text-lg font-medium text-gray-900 mb-4">{title}</h3>
+          <p className="text-sm text-gray-500 mb-4">{message}</p>
+          
+          {error && (
+            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
+              <p className="text-sm text-red-600">{error}</p>
+            </div>
+          )}
+
+          <div className="flex justify-end space-x-3">
+            <button
+              onClick={onCancel}
+              disabled={isDeleting}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={onConfirm}
+              disabled={isDeleting}
+              className="px-4 py-2 text-sm font-medium text-white bg-red-600 border border-transparent rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isDeleting ? "Deleting..." : "Delete"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/ui/admin/RecruitsTable.tsx
+++ b/src/app/ui/admin/RecruitsTable.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState } from "react";
+import { RecruitOverviewField } from "@/app/lib/definitions";
+import { deleteRecruit } from "@/app/lib/actions";
+import { useRouter } from "next/navigation";
+import DeleteConfirmationModal from "./DeleteConfirmationModal";
+
+interface RecruitsTableProps {
+  recruits: RecruitOverviewField[];
+  adminId: string;
+}
+
+export default function RecruitsTable({ recruits, adminId }: RecruitsTableProps) {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const filteredRecruits = recruits.filter((recruit) => {
+    const searchLower = searchTerm.toLowerCase();
+    return (
+      recruit.first_name.toLowerCase().includes(searchLower) ||
+      recruit.last_name.toLowerCase().includes(searchLower) ||
+      recruit.room.toLowerCase().includes(searchLower)
+    );
+  });
+
+  const handleDeleteClick = (recruit: RecruitOverviewField) => {
+    setDeleteTarget({
+      id: recruit.id,
+      name: `${recruit.first_name} ${recruit.last_name}`,
+    });
+    setError(null);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!deleteTarget) return;
+
+    setIsDeleting(true);
+    setError(null);
+
+    try {
+      const result = await deleteRecruit(deleteTarget.id, adminId);
+      
+      if (result.success) {
+        setDeleteTarget(null);
+        router.refresh();
+      } else {
+        setError(result.message);
+      }
+    } catch {
+      setError("An unexpected error occurred.");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleCancelDelete = () => {
+    setDeleteTarget(null);
+    setError(null);
+  };
+
+  return (
+    <div>
+      <div className="mb-4">
+        <input
+          type="text"
+          placeholder="Search recruits by name or room..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        />
+      </div>
+
+      <div className="bg-white shadow-md rounded-lg overflow-hidden">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Name
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Room
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Year
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {filteredRecruits.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-6 py-4 text-center text-gray-500">
+                  No recruits found
+                </td>
+              </tr>
+            ) : (
+              filteredRecruits.map((recruit) => (
+                <tr key={recruit.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <div className="flex items-center">
+                      <div className="h-10 w-10 flex-shrink-0">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          className="h-10 w-10 rounded-full object-cover"
+                          src={recruit.image_url}
+                          alt={`${recruit.first_name} ${recruit.last_name}`}
+                        />
+                      </div>
+                      <div className="ml-4">
+                        <div className="text-sm font-medium text-gray-900">
+                          {recruit.first_name} {recruit.last_name}
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {recruit.room}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {recruit.year}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                    <button
+                      onClick={() => handleDeleteClick(recruit)}
+                      className="text-red-600 hover:text-red-900 transition-colors"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {deleteTarget && (
+        <DeleteConfirmationModal
+          title="Delete Recruit"
+          message={`Are you sure you want to delete ${deleteTarget.name}? This action cannot be undone and will also delete all associated comments.`}
+          onConfirm={handleConfirmDelete}
+          onCancel={handleCancelDelete}
+          isDeleting={isDeleting}
+          error={error}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -7,15 +7,20 @@ export const authConfig = {
   callbacks: {
     authorized({ auth, request: { nextUrl } }) {
       const isLoggedIn = !!auth?.user;
+      const isAdmin = !!auth?.user?.isAdmin;
       const isOnRecruits = nextUrl.pathname.startsWith('/recruits');
+      const isOnAdmin = nextUrl.pathname.startsWith('/admin');
 
-      // Allow logged-in users to access all pages freely
+      if (isOnAdmin) {
+        if (!isLoggedIn) return false;
+        if (!isAdmin) return false;
+        return true;
+      }
+
       if (isLoggedIn) return true;
 
-      // If on /recruits and not logged in, redirect to login
       if (isOnRecruits) return false;
 
-      // Otherwise, allow access
       return true;
     },
   },

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -53,6 +53,7 @@ export const authOptions = {
         const brother = user as BrotherUser;
         token.id = brother.id;
         token.email = brother.personal_email;
+        token.isAdmin = brother.is_admin;
       }
       return token;
     },
@@ -61,6 +62,7 @@ export const authOptions = {
       if (session.user) {
         session.user.id = token.id as string;
         session.user.email = token.email as string;
+        session.user.isAdmin = token.isAdmin as boolean;
       }
       return session;
     }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,7 +6,6 @@ import postgres from "postgres";
 import { authConfig } from "./auth.config";
 import type { Session, User } from "next-auth";
 import type { JWT } from "next-auth/jwt";
-import { BrotherUser } from "./app/lib/definitions";
 
 const sql = postgres(process.env.POSTGRES_URL!, { ssl: "require" });
 
@@ -24,7 +23,7 @@ export const authOptions = {
   ...authConfig,
   providers: [
     Credentials({
-      async authorize(credentials): Promise<BrotherUser | null> {
+      async authorize(credentials): Promise<User | null> {
         const parsedCredentials = z
           .object({ email: z.string().email(), password: z.string().min(6) })
           .safeParse(credentials);
@@ -41,19 +40,20 @@ export const authOptions = {
         const passwordsMatch = await bcrypt.compare(password, user.password);
         if (!passwordsMatch) return null;
         
-        // Return the user object that you want to store in the JWT
-        return user as BrotherUser;
+        return {
+          id: user.id,
+          email: user.personal_email,
+          isAdmin: user.is_admin,
+        };
       },
     }),
   ],
   callbacks: {
     async jwt({ token, user }: { token: JWT; user?: User }) {
       if (user) {
-        // Attach any fields you want
-        const brother = user as BrotherUser;
-        token.id = brother.id;
-        token.email = brother.personal_email;
-        token.isAdmin = brother.is_admin;
+        token.id = user.id as string;
+        token.email = user.email as string;
+        token.isAdmin = user.isAdmin as boolean;
       }
       return token;
     },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -10,9 +10,9 @@ declare module "next-auth" {
   }
 
   interface User {
-    id: string;
-    email: string;
-    isAdmin: boolean;
+    id?: string;
+    email?: string;
+    isAdmin?: boolean;
   }
 }
 

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,25 @@
+import { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+      email: string;
+      isAdmin: boolean;
+    } & DefaultSession["user"];
+  }
+
+  interface User {
+    id: string;
+    email: string;
+    isAdmin: boolean;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    id: string;
+    email: string;
+    isAdmin: boolean;
+  }
+}


### PR DESCRIPTION
# Add admin dashboard with delete functionality and authorization

## Summary

This PR implements an admin dashboard at `/admin` that allows designated users to delete brother and recruit profiles. The implementation includes database schema changes, authentication updates, server actions for deletion operations with proper authorization, and a full-featured UI with search and confirmation dialogs.

**Key Changes:**
- Added `is_admin` boolean column to `brothers` table (manual migration)
- Extended NextAuth session to include admin status with proper TypeScript types
- Created `deleteBrother` and `deleteRecruit` server actions with:
  - Admin authorization checks (defense in depth: middleware + server action)
  - Cascade deletion of related comments
  - Blob storage cleanup for profile images
  - Last-admin protection (prevents deleting the only admin)
  - Audit logging to console
- Built admin dashboard UI with tabbed interface, searchable tables, delete buttons with confirmation dialogs
- Added middleware protection to block unauthorized access to `/admin` routes

## Review & Testing Checklist for Human

**CRITICAL - Database Setup Required (must do before testing):**
- [ ] **Run database migration**: Execute `ALTER TABLE brothers ADD COLUMN IF NOT EXISTS is_admin BOOLEAN DEFAULT FALSE;` on all environments
- [ ] **Create first admin user**: Run `UPDATE brothers SET is_admin = TRUE WHERE personal_email = 'your-email@example.com';` to set yourself as admin

**Core Functionality Testing:**
- [ ] Verify non-admin users cannot access `/admin` (should redirect to login or show "Access Denied")
- [ ] Log in as admin and verify you can access `/admin` successfully
- [ ] Test deleting a brother profile and verify:
  - Confirmation dialog appears with correct name
  - After confirming, brother is removed from list
  - Associated comments are deleted (check database or recruit profiles)
  - Profile image is removed from Vercel Blob storage
- [ ] Test deleting a recruit profile with same verification steps
- [ ] Test last-admin protection: Try to delete the only admin user (should show error: "Cannot delete the last admin")
- [ ] Test search functionality on both Brothers and Recruits tabs

**Edge Cases & Security:**
- [ ] Verify middleware blocks `/admin` access for logged-out users (redirects to login)
- [ ] Check that non-admin logged-in users see "Access Denied" page at `/admin`
- [ ] Verify audit logs appear in server console when deletions occur (format: `[AUDIT] Brother/Recruit {id} deleted by admin {adminId} at {timestamp}`)

### Notes

**Database Migration Risk**: The `is_admin` column was added via manual SQL execution and is not tracked in version control. You'll need to ensure this migration is applied to staging/production environments before deploying this code.

**No Admin Users by Default**: After deployment, no users will be admins initially. You must manually update the database to set at least one user as admin, or no one will be able to access the admin dashboard.

**Blob Storage Cleanup**: If blob deletion fails, the operation continues with success (database record is still deleted). This could lead to orphaned blobs in storage, but the database is the source of truth. Consider monitoring blob storage usage over time.

**Type Safety**: The implementation uses type assertions in the JWT callback (`as string`, `as boolean`). This is necessary due to NextAuth's optional User fields, but be aware that type safety is reduced here.

**No Transaction Wrapping**: The deletion operations (comments → brother/recruit → blob) are not wrapped in a database transaction. If a later step fails, earlier deletions persist. This is probably acceptable for this use case but worth noting.

---

**Link to Devin run:** https://app.devin.ai/sessions/3dad410dcc4149f2a229931a0d956b3c  
**Requested by:** mvu@college.harvard.edu (@mmattyV)

**Fixes #2**