### PR TITLE
Fix dupe images

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "cleanup-images": "tsx scripts/cleanup-unused-images.ts",
+    "cleanup-images:execute": "tsx scripts/cleanup-unused-images.ts --execute"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/src/app/lib/actions.ts
+++ b/src/app/lib/actions.ts
@@ -12,7 +12,8 @@ import { BrotherSchema, RecruitSchema, EditBrotherSchema } from "./zod-schemas";
 import bcrypt from "bcrypt";
 import { validateImageFile } from "@/app/utils/validateImage";
 import { sanitizeFilename } from "@/app/utils/sanitizeFilename";
-import { compressImage } from "@/app/utils/compressImage";
+import { generateImageVariants } from "@/app/utils/compressImage";
+import { serializeImageUrls } from "@/app/utils/imageUrlHelper";
 
 // ============= AUTH / SIGNIN / SIGNOUT =================
 export async function authenticate(
@@ -244,15 +245,34 @@ export async function createBrotherAccount(
   // 4) Hash password
   const hashedPassword = await bcrypt.hash(parsed.data.password, 10);
 
-  // 5) Compress and upload image to Vercel Blob
+  // 5) Generate image variants and upload to Vercel Blob
   try {
-    // Compress the image
-    const { buffer: fileBuffer, contentType } = await compressImage(imageFile);
+    // Generate thumbnail, medium, and full size images
+    const variants = await generateImageVariants(imageFile);
     const sanitizedFilename = sanitizeFilename(imageFile.name);
-    const fileName = `brother-profile-${randomUUID()}-${sanitizedFilename}`;
-    const { url } = await put(fileName, fileBuffer, {
-      access: "public",
-      contentType: contentType,
+    const baseFileName = `brother-profile-${randomUUID()}-${sanitizedFilename}`;
+    
+    // Upload all three sizes in parallel
+    const [thumbResult, mediumResult, fullResult] = await Promise.all([
+      put(`${baseFileName}-thumb.jpg`, variants.thumbnail, {
+        access: "public",
+        contentType: "image/jpeg",
+      }),
+      put(`${baseFileName}-medium.jpg`, variants.medium, {
+        access: "public",
+        contentType: "image/jpeg",
+      }),
+      put(`${baseFileName}-full.jpg`, variants.full, {
+        access: "public",
+        contentType: "image/jpeg",
+      }),
+    ]);
+    
+    // Store all URLs as JSON string
+    const url = serializeImageUrls({
+      thumbnail: thumbResult.url,
+      medium: mediumResult.url,
+      full: fullResult.url,
     });
 
     // 6) Insert into DB
@@ -340,13 +360,32 @@ export async function createRecruitAccount(
   }
 
   try {
-    // Compress and upload image
-    const { buffer: fileBuffer, contentType } = await compressImage(imageFile);
+    // Generate image variants and upload
+    const variants = await generateImageVariants(imageFile);
     const sanitizedFilename = sanitizeFilename(imageFile.name);
-    const fileName = `brother-profile-${randomUUID()}-${sanitizedFilename}`;
-    const { url } = await put(fileName, fileBuffer, {
-      access: "public",
-      contentType: contentType,
+    const baseFileName = `recruit-profile-${randomUUID()}-${sanitizedFilename}`;
+    
+    // Upload all three sizes in parallel
+    const [thumbResult, mediumResult, fullResult] = await Promise.all([
+      put(`${baseFileName}-thumb.jpg`, variants.thumbnail, {
+        access: "public",
+        contentType: "image/jpeg",
+      }),
+      put(`${baseFileName}-medium.jpg`, variants.medium, {
+        access: "public",
+        contentType: "image/jpeg",
+      }),
+      put(`${baseFileName}-full.jpg`, variants.full, {
+        access: "public",
+        contentType: "image/jpeg",
+      }),
+    ]);
+    
+    // Store all URLs as JSON string
+    const url = serializeImageUrls({
+      thumbnail: thumbResult.url,
+      medium: mediumResult.url,
+      full: fullResult.url,
     });
 
     // Insert recruit
@@ -441,38 +480,73 @@ export async function updateBrotherProfile(
   const imageFile = parsed.data.image;
 
   if (imageFile) {
-    // ✅ Fetch old image URL before uploading new one
-    let oldImageUrl: string | null = null;
+    // ✅ Fetch old image URL(s) before uploading new one
+    let oldImageUrls: string[] = [];
     try {
       const existingBrother =
         await sql`SELECT image_url FROM brothers WHERE id = ${parsed.data.brotherId}`;
       if (existingBrother.rows.length > 0) {
-        oldImageUrl = existingBrother.rows[0].image_url;
+        const oldImageUrl = existingBrother.rows[0].image_url;
+        // Parse old URLs to delete all variants
+        try {
+          const parsed = JSON.parse(oldImageUrl);
+          if (parsed.thumbnail && parsed.medium && parsed.full) {
+            oldImageUrls = [parsed.thumbnail, parsed.medium, parsed.full];
+          } else {
+            oldImageUrls = [oldImageUrl]; // Legacy single URL
+          }
+        } catch {
+          oldImageUrls = [oldImageUrl]; // Legacy single URL
+        }
       }
     } catch (error) {
       console.error("Error fetching existing image:", error);
     }
 
-    // ✅ Compress and upload new image
+    // ✅ Generate image variants and upload new images
     try {
-      const { buffer: fileBuffer, contentType } = await compressImage(imageFile);
+      const variants = await generateImageVariants(imageFile);
       const sanitizedFilename = sanitizeFilename(imageFile.name);
-      const fileName = `brother-profile-${randomUUID()}-${sanitizedFilename}`;
-      const { url } = await put(fileName, fileBuffer, {
-        access: "public",
-        contentType: contentType,
+      const baseFileName = `brother-profile-${randomUUID()}-${sanitizedFilename}`;
+      
+      // Upload all three sizes in parallel
+      const [thumbResult, mediumResult, fullResult] = await Promise.all([
+        put(`${baseFileName}-thumb.jpg`, variants.thumbnail, {
+          access: "public",
+          contentType: "image/jpeg",
+        }),
+        put(`${baseFileName}-medium.jpg`, variants.medium, {
+          access: "public",
+          contentType: "image/jpeg",
+        }),
+        put(`${baseFileName}-full.jpg`, variants.full, {
+          access: "public",
+          contentType: "image/jpeg",
+        }),
+      ]);
+      
+      // Store all URLs as JSON string
+      newImageUrl = serializeImageUrls({
+        thumbnail: thumbResult.url,
+        medium: mediumResult.url,
+        full: fullResult.url,
       });
-      newImageUrl = url;
 
-      // ✅ Delete old image from blob storage (non-blocking)
-      if (oldImageUrl) {
-        try {
-          await del(oldImageUrl);
-          console.log(`Successfully deleted old image: ${oldImageUrl}`);
-        } catch (error) {
-          console.error("Failed to delete old image:", error);
-          // Don't fail the update if deletion fails
-        }
+      // ✅ Delete all old image variants from blob storage (non-blocking)
+      if (oldImageUrls.length > 0) {
+        // Delete old images in parallel but don't wait for completion
+        Promise.all(
+          oldImageUrls.map(async (url) => {
+            try {
+              await del(url);
+              console.log(`Successfully deleted old image: ${url}`);
+            } catch (error) {
+              console.error(`Failed to delete old image: ${url}`, error);
+            }
+          })
+        ).catch((error) => {
+          console.error("Error during batch deletion:", error);
+        });
       }
     } catch (error) {
       console.error("Image Upload Error:", error);

--- a/src/app/lib/actions.ts
+++ b/src/app/lib/actions.ts
@@ -7,11 +7,12 @@ import { sql } from "@vercel/postgres";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { randomUUID } from "crypto";
-import { put } from "@vercel/blob";
+import { put, del } from "@vercel/blob";
 import { BrotherSchema, RecruitSchema, EditBrotherSchema } from "./zod-schemas";
 import bcrypt from "bcrypt";
 import { validateImageFile } from "@/app/utils/validateImage";
 import { sanitizeFilename } from "@/app/utils/sanitizeFilename";
+import { compressImage } from "@/app/utils/compressImage";
 
 // ============= AUTH / SIGNIN / SIGNOUT =================
 export async function authenticate(
@@ -243,14 +244,15 @@ export async function createBrotherAccount(
   // 4) Hash password
   const hashedPassword = await bcrypt.hash(parsed.data.password, 10);
 
-  // 5) Upload image to Vercel Blob
+  // 5) Compress and upload image to Vercel Blob
   try {
-    const fileBuffer = Buffer.from(await imageFile.arrayBuffer());
+    // Compress the image
+    const { buffer: fileBuffer, contentType } = await compressImage(imageFile);
     const sanitizedFilename = sanitizeFilename(imageFile.name);
     const fileName = `brother-profile-${randomUUID()}-${sanitizedFilename}`;
     const { url } = await put(fileName, fileBuffer, {
       access: "public",
-      contentType: imageFile.type,
+      contentType: contentType,
     });
 
     // 6) Insert into DB
@@ -338,13 +340,13 @@ export async function createRecruitAccount(
   }
 
   try {
-    // Upload image directly without conversion
-    const fileBuffer = Buffer.from(await imageFile.arrayBuffer());
+    // Compress and upload image
+    const { buffer: fileBuffer, contentType } = await compressImage(imageFile);
     const sanitizedFilename = sanitizeFilename(imageFile.name);
     const fileName = `brother-profile-${randomUUID()}-${sanitizedFilename}`;
     const { url } = await put(fileName, fileBuffer, {
       access: "public",
-      contentType: imageFile.type,
+      contentType: contentType,
     });
 
     // Insert recruit
@@ -439,16 +441,39 @@ export async function updateBrotherProfile(
   const imageFile = parsed.data.image;
 
   if (imageFile) {
-    // ✅ Upload new image
+    // ✅ Fetch old image URL before uploading new one
+    let oldImageUrl: string | null = null;
     try {
-      const fileBuffer = Buffer.from(await imageFile.arrayBuffer());
+      const existingBrother =
+        await sql`SELECT image_url FROM brothers WHERE id = ${parsed.data.brotherId}`;
+      if (existingBrother.rows.length > 0) {
+        oldImageUrl = existingBrother.rows[0].image_url;
+      }
+    } catch (error) {
+      console.error("Error fetching existing image:", error);
+    }
+
+    // ✅ Compress and upload new image
+    try {
+      const { buffer: fileBuffer, contentType } = await compressImage(imageFile);
       const sanitizedFilename = sanitizeFilename(imageFile.name);
       const fileName = `brother-profile-${randomUUID()}-${sanitizedFilename}`;
       const { url } = await put(fileName, fileBuffer, {
         access: "public",
-        contentType: imageFile.type,
+        contentType: contentType,
       });
       newImageUrl = url;
+
+      // ✅ Delete old image from blob storage (non-blocking)
+      if (oldImageUrl) {
+        try {
+          await del(oldImageUrl);
+          console.log(`Successfully deleted old image: ${oldImageUrl}`);
+        } catch (error) {
+          console.error("Failed to delete old image:", error);
+          // Don't fail the update if deletion fails
+        }
+      }
     } catch (error) {
       console.error("Image Upload Error:", error);
       return { message: "Failed to upload new photo." };

--- a/src/app/lib/definitions.ts
+++ b/src/app/lib/definitions.ts
@@ -146,6 +146,7 @@ export interface BrotherCardProps {
   house: string;
   position: string;
   image_url: string;
+  priority?: boolean; // For prioritizing above-fold images
 }
 
 export interface RecruitCardProps {
@@ -154,6 +155,7 @@ export interface RecruitCardProps {
   last_name: string;
   room: string;
   image_url: string;
+  priority?: boolean; // For prioritizing above-fold images
 }
 
 export interface BrotherYearSectionProps {

--- a/src/app/signup/brother/page.tsx
+++ b/src/app/signup/brother/page.tsx
@@ -20,6 +20,14 @@ export default function BrotherSignUpPage() {
     setImageError(null);
     const file = e.target.files?.[0];
     if (file) {
+      // Check file size (5MB limit)
+      const maxSize = 5 * 1024 * 1024; // 5MB in bytes
+      if (file.size > maxSize) {
+        setImageError("Image must be under 5MB");
+        e.target.value = ""; // Reset the input
+        return;
+      }
+
       const allowedExtensions = ["jpeg", "jpg", "png"];
       const allowedMimeTypes = ["image/jpeg", "image/png"];
 
@@ -31,6 +39,7 @@ export default function BrotherSignUpPage() {
       if (!isValidExtension || !isValidMimeType) {
         setImageError("Only JPEG, JPG, and PNG files are allowed.");
         e.target.value = ""; // Reset the input
+        return;
       }
 
       if (isValidExtension && isValidMimeType) {

--- a/src/app/signup/recruit/page.tsx
+++ b/src/app/signup/recruit/page.tsx
@@ -20,6 +20,14 @@ export default function RecruitSignUpPage() {
     setImageError(null);
     const file = e.target.files?.[0];
     if (file) {
+      // Check file size (5MB limit)
+      const maxSize = 5 * 1024 * 1024; // 5MB in bytes
+      if (file.size > maxSize) {
+        setImageError("Image must be under 5MB");
+        e.target.value = ""; // Reset the input
+        return;
+      }
+
       const allowedExtensions = ["jpeg", "jpg", "png"];
       const allowedMimeTypes = ["image/jpeg", "image/png"];
 
@@ -31,6 +39,7 @@ export default function RecruitSignUpPage() {
       if (!isValidExtension || !isValidMimeType) {
         setImageError("Only JPEG, JPG, and PNG files are allowed.");
         e.target.value = ""; // Reset the input
+        return;
       }
       if (isValidExtension && isValidMimeType) {
         const reader = new FileReader();

--- a/src/app/ui/brothers/BrotherCard.tsx
+++ b/src/app/ui/brothers/BrotherCard.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { BrotherCardProps } from "@/app/lib/definitions";
-import Link from "next/link"; // For Next.js routing
+import Link from "next/link";
+import Image from "next/image";
+import { getImageUrl } from "@/app/utils/imageUrlHelper";
 
 export const BrotherCard: React.FC<BrotherCardProps> = ({
   first_name,
@@ -8,26 +10,36 @@ export const BrotherCard: React.FC<BrotherCardProps> = ({
   house,
   position,
   image_url,
-  id
+  id,
+  priority = false, // Add priority prop for above-fold images
 }) => {
+  // Use thumbnail size for cards (400px width)
+  const thumbnailUrl = getImageUrl(image_url, 'thumbnail');
   
   return (
     <Link
-      href={`/brothers/${id}/details`} // Link to the brother's details page
+      href={`/brothers/${id}/details`}
       passHref
     >
       <div
-        className="relative flex-none basis-[230px] aspect-[3/4] bg-center bg-no-repeat bg-cover cursor-pointer
-                   transition-all duration-300 group"
-        style={{
-          backgroundImage: `url(${image_url})`,
-        }}
+        className="relative flex-none basis-[230px] aspect-[3/4] cursor-pointer
+                   transition-all duration-300 group overflow-hidden"
       >
+        {/* Next.js optimized image with lazy loading */}
+        <Image
+          src={thumbnailUrl}
+          alt={`${first_name} ${last_name}`}
+          fill
+          sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 230px"
+          className="object-cover"
+          priority={priority}
+        />
+
         {/* Overlay to force the hover effect on both image and text */}
-        <div className="absolute inset-0 bg-brandRed opacity-0 group-hover:opacity-100 transition-opacity duration-300 mix-blend-screen"></div>
+        <div className="absolute inset-0 bg-brandRed opacity-0 group-hover:opacity-100 transition-opacity duration-300 mix-blend-screen z-10"></div>
 
         {/* Text Container Positioned at Bottom Left, Always White */}
-        <div className="absolute bottom-4 left-4 text-white z-10 group-hover:text-white transition-colors duration-300">
+        <div className="absolute bottom-4 left-4 text-white z-20 group-hover:text-white transition-colors duration-300">
           <div className="text-3xl text-shadow-sm leading-none">
             {first_name + " " + last_name}
           </div>

--- a/src/app/ui/brothers/BrotherProfile.tsx
+++ b/src/app/ui/brothers/BrotherProfile.tsx
@@ -3,6 +3,7 @@ import BackToButton from "@/app/ui/components/BackToButton";
 import Image from "next/image";
 import { ContactSection } from "@/app/ui/components/ContactSection";
 import { BrotherProfileProps, ContactInfo } from "@/app/lib/definitions";
+import { getImageUrl } from "@/app/utils/imageUrlHelper";
 
 function formatDate(date: string | Date | null | undefined) {
   if (!date) return "Not provided";
@@ -32,6 +33,9 @@ export function BrotherProfile({
   image_url = "https://via.placeholder.com/150",
   isLoggedIn = false,
 }: BrotherProfileComponentProps) {
+  // Use full-size image for profile page
+  const fullImageUrl = getImageUrl(image_url, 'full');
+  
   // Build the contacts array
   // Always show personal & school emails
   // Only show phone & instagram if user is logged in
@@ -87,10 +91,11 @@ export function BrotherProfile({
         "
       >
         <Image
-          src={image_url}
+          src={fullImageUrl}
           alt={`Profile of ${first_name} ${last_name}`}
           width={487}
           height={650}
+          priority
           className="
             object-contain
             w-full

--- a/src/app/ui/brothers/BrotherYearSection.tsx
+++ b/src/app/ui/brothers/BrotherYearSection.tsx
@@ -17,7 +17,10 @@ export const BrotherYearSection: React.FC<BrotherYearSectionProps> = ({
       <div className="flex flex-wrap gap-11 justify-start pl-3 mt-3 w-full">
         {brothers.map((brother, index) => (
           <div key={index} className="flex-none basis-[230px]">
-            <BrotherCard {...brother} />
+            <BrotherCard 
+              {...brother} 
+              priority={index < 4} // Prioritize first 4 cards (typically above the fold)
+            />
           </div>
         ))}
       </div>

--- a/src/app/ui/components/EditProfileForm.tsx
+++ b/src/app/ui/components/EditProfileForm.tsx
@@ -27,6 +27,14 @@ export default function EditProfileForm({
     setImageError(null);
     const file = e.target.files?.[0];
     if (file) {
+      // Check file size (5MB limit)
+      const maxSize = 5 * 1024 * 1024; // 5MB in bytes
+      if (file.size > maxSize) {
+        setImageError("Image must be under 5MB");
+        e.target.value = ""; // Reset the input
+        return;
+      }
+
       const allowedExtensions = ["jpeg", "jpg", "png"];
       const allowedMimeTypes = ["image/jpeg", "image/png"];
 
@@ -38,6 +46,7 @@ export default function EditProfileForm({
       if (!isValidExtension || !isValidMimeType) {
         setImageError("Only JPEG, JPG, and PNG files are allowed.");
         e.target.value = ""; // Reset the input
+        return;
       }
       if (isValidExtension && isValidMimeType) {
         const reader = new FileReader();

--- a/src/app/ui/recruits/RecruitCard.tsx
+++ b/src/app/ui/recruits/RecruitCard.tsx
@@ -1,31 +1,44 @@
 import * as React from "react";
 import { RecruitCardProps } from "@/app/lib/definitions";
-import Link from "next/link"; // For Next.js routing
+import Link from "next/link";
+import Image from "next/image";
+import { getImageUrl } from "@/app/utils/imageUrlHelper";
 
 export const RecruitCard: React.FC<RecruitCardProps> = ({
   first_name,
   last_name,
   room,
   image_url,
-  id
+  id,
+  priority = false, // Add priority prop for above-fold images
 }) => {
+  // Use thumbnail size for cards (400px width)
+  const thumbnailUrl = getImageUrl(image_url, 'thumbnail');
+  
   return (
     <Link
-      href={`/recruits/${id}/details`} // Link to the recruits's details page
+      href={`/recruits/${id}/details`}
       passHref
     >
       <div
-        className="relative flex-none basis-[230px] aspect-[3/4] bg-center bg-no-repeat bg-cover cursor-pointer
-                   transition-all duration-300 group"
-        style={{
-          backgroundImage: `url(${image_url})`,
-        }}
+        className="relative flex-none basis-[230px] aspect-[3/4] cursor-pointer
+                   transition-all duration-300 group overflow-hidden"
       >
+        {/* Next.js optimized image with lazy loading */}
+        <Image
+          src={thumbnailUrl}
+          alt={`${first_name} ${last_name}`}
+          fill
+          sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 230px"
+          className="object-cover"
+          priority={priority}
+        />
+
         {/* Overlay to force the hover effect on both image and text */}
-        <div className="absolute inset-0 bg-brandRed opacity-0 group-hover:opacity-100 transition-opacity duration-300 mix-blend-screen"></div>
+        <div className="absolute inset-0 bg-brandRed opacity-0 group-hover:opacity-100 transition-opacity duration-300 mix-blend-screen z-10"></div>
 
         {/* Text Container Positioned at Bottom Left, Always White */}
-        <div className="absolute bottom-4 left-4 text-white z-10 group-hover:text-white transition-colors duration-300">
+        <div className="absolute bottom-4 left-4 text-white z-20 group-hover:text-white transition-colors duration-300">
           <div className="text-3xl text-shadow-lg leading-none">
             {first_name + " " + last_name}
           </div>

--- a/src/app/ui/recruits/RecruitProfile.tsx
+++ b/src/app/ui/recruits/RecruitProfile.tsx
@@ -12,6 +12,7 @@ import {
 import { auth } from "@/auth"; // Correctly import auth from auth.ts
 import Link from "next/link";
 import { FaEdit, FaPlus } from "react-icons/fa";
+import { getImageUrl } from "@/app/utils/imageUrlHelper";
 
 export async function RecruitProfile({
   id = "",
@@ -24,6 +25,9 @@ export async function RecruitProfile({
   image_url = "https://via.placeholder.com/150",
   comments = [],
 }: RecruitProfileProps & { comments: RecruitCommentProps[] }) {
+  // Use full-size image for profile page
+  const fullImageUrl = getImageUrl(image_url, 'full');
+  
   // 1. Get the logged-in user
   const session = await auth();
   if (!session || !session.user?.email || !session.user?.id) {
@@ -88,10 +92,11 @@ export async function RecruitProfile({
       {/* Image + Button + Text */}
       <div className="relative flex flex-col md:flex-row items-start gap-4 mt-12 max-md:mt-10 max-md:max-w-full md:pr-52">
         <Image
-          src={image_url}
+          src={fullImageUrl}
           alt={`Profile of ${first_name} ${last_name}`}
           width={487}
           height={650}
+          priority
           className="object-contain w-full max-w-[487px] aspect-[0.75] min-w-[400px] max-md:mx-auto"
         />
 

--- a/src/app/ui/recruits/RecruitYearSection.tsx
+++ b/src/app/ui/recruits/RecruitYearSection.tsx
@@ -17,7 +17,10 @@ export const RecruitYearSection: React.FC<RecruitYearSectionProps> = ({
       <div className="flex flex-wrap gap-11 justify-start pl-3 mt-3 w-full">
         {recruits.map((recruit, index) => (
           <div key={index} className="flex-none basis-[230px]">
-            <RecruitCard {...recruit} />
+            <RecruitCard 
+              {...recruit} 
+              priority={index < 4} // Prioritize first 4 cards (typically above the fold)
+            />
           </div>
         ))}
       </div>

--- a/src/app/utils/compressImage.ts
+++ b/src/app/utils/compressImage.ts
@@ -1,0 +1,38 @@
+import sharp from 'sharp';
+
+/**
+ * Compresses and optimizes an image file
+ * - Resizes to max width of 1200px (maintains aspect ratio)
+ * - Converts to JPEG with 85% quality
+ * - Strips metadata
+ * 
+ * @param file - The image file to compress
+ * @returns Object with compressed buffer and content type
+ */
+export async function compressImage(file: File): Promise<{ buffer: Buffer; contentType: string }> {
+  try {
+    // Convert File to Buffer
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    
+    // Compress and optimize with Sharp
+    const compressed = await sharp(buffer)
+      .resize(1200, null, { 
+        withoutEnlargement: true, // Don't upscale smaller images
+        fit: 'inside' // Maintain aspect ratio
+      })
+      .jpeg({ 
+        quality: 85, // Good balance between quality and size
+        progressive: true // Progressive loading
+      })
+      .toBuffer();
+    
+    return { 
+      buffer: compressed, 
+      contentType: 'image/jpeg' 
+    };
+  } catch (error) {
+    console.error('Image compression error:', error);
+    throw new Error('Failed to compress image. Please try a different image.');
+  }
+}

--- a/src/app/utils/compressImage.ts
+++ b/src/app/utils/compressImage.ts
@@ -1,6 +1,15 @@
 import sharp from 'sharp';
 
 /**
+ * Image size variants for different use cases
+ */
+export interface ImageVariants {
+  thumbnail: Buffer;  // 400px width - for cards/lists
+  medium: Buffer;     // 800px width - for smaller screens
+  full: Buffer;       // 1200px width - for profile pages
+}
+
+/**
  * Compresses and optimizes an image file
  * - Resizes to max width of 1200px (maintains aspect ratio)
  * - Converts to JPEG with 85% quality
@@ -34,5 +43,63 @@ export async function compressImage(file: File): Promise<{ buffer: Buffer; conte
   } catch (error) {
     console.error('Image compression error:', error);
     throw new Error('Failed to compress image. Please try a different image.');
+  }
+}
+
+/**
+ * Generates multiple image size variants for responsive loading
+ * - Thumbnail: 400px width (for cards/grid views)
+ * - Medium: 800px width (for smaller screens)
+ * - Full: 1200px width (for profile pages/large screens)
+ * 
+ * @param file - The image file to process
+ * @returns Object with all three size variants as buffers
+ */
+export async function generateImageVariants(file: File): Promise<ImageVariants> {
+  try {
+    // Convert File to Buffer
+    const arrayBuffer = await file.arrayBuffer();
+    const sourceBuffer = Buffer.from(arrayBuffer);
+    
+    // Create a sharp instance from the source
+    const image = sharp(sourceBuffer);
+    
+    // Generate all three sizes in parallel for better performance
+    const [thumbnail, medium, full] = await Promise.all([
+      // Thumbnail: 400px width for cards
+      image
+        .clone()
+        .resize(400, null, { 
+          withoutEnlargement: true,
+          fit: 'inside'
+        })
+        .jpeg({ quality: 85, progressive: true })
+        .toBuffer(),
+      
+      // Medium: 800px width for smaller screens
+      image
+        .clone()
+        .resize(800, null, { 
+          withoutEnlargement: true,
+          fit: 'inside'
+        })
+        .jpeg({ quality: 85, progressive: true })
+        .toBuffer(),
+      
+      // Full: 1200px width for profile pages
+      image
+        .clone()
+        .resize(1200, null, { 
+          withoutEnlargement: true,
+          fit: 'inside'
+        })
+        .jpeg({ quality: 85, progressive: true })
+        .toBuffer(),
+    ]);
+    
+    return { thumbnail, medium, full };
+  } catch (error) {
+    console.error('Image variant generation error:', error);
+    throw new Error('Failed to generate image variants. Please try a different image.');
   }
 }

--- a/src/app/utils/imageUrlHelper.ts
+++ b/src/app/utils/imageUrlHelper.ts
@@ -1,0 +1,59 @@
+/**
+ * Helper functions for managing multiple image size URLs
+ * Provides backwards compatibility with single URL format
+ */
+
+export interface ImageUrls {
+  thumbnail: string;
+  medium: string;
+  full: string;
+}
+
+/**
+ * Parse image_url field which can be either:
+ * - A JSON string with thumbnail, medium, full URLs
+ * - A plain URL string (legacy format)
+ * 
+ * @param imageUrlField - The image_url value from database
+ * @returns ImageUrls object with all three sizes
+ */
+export function parseImageUrl(imageUrlField: string): ImageUrls {
+  try {
+    // Try to parse as JSON
+    const parsed = JSON.parse(imageUrlField);
+    if (parsed.thumbnail && parsed.medium && parsed.full) {
+      return parsed;
+    }
+  } catch {
+    // Not JSON, treat as plain URL
+  }
+  
+  // If not JSON or invalid structure, use the URL for all sizes (backwards compatible)
+  return {
+    thumbnail: imageUrlField,
+    medium: imageUrlField,
+    full: imageUrlField,
+  };
+}
+
+/**
+ * Convert ImageUrls object to JSON string for storage
+ * 
+ * @param urls - ImageUrls object
+ * @returns JSON string for database storage
+ */
+export function serializeImageUrls(urls: ImageUrls): string {
+  return JSON.stringify(urls);
+}
+
+/**
+ * Get the appropriate image URL based on usage context
+ * 
+ * @param imageUrlField - The image_url value from database
+ * @param size - Which size to retrieve
+ * @returns The URL for the requested size
+ */
+export function getImageUrl(imageUrlField: string, size: 'thumbnail' | 'medium' | 'full' = 'full'): string {
+  const urls = parseImageUrl(imageUrlField);
+  return urls[size];
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches image upload/storage format and introduces blob deletion; issues could lead to broken images or unintended deletions if URL parsing/storage assumptions are wrong, though legacy single-URL fallback reduces migration risk.
> 
> **Overview**
> Updates profile image handling to **generate and store multiple size variants** (thumbnail/medium/full) for brothers and recruits: uploads JPEG variants via Sharp, persists the URLs as a JSON string in `image_url`, and adds helpers (`imageUrlHelper`) to keep legacy single-URL rows working.
> 
> Switches brother/recruit cards and profile pages to `next/image` and to pick the appropriate variant (thumbnail for cards, full for profiles), adds `priority` support for above-the-fold cards, and adds a 5MB client-side upload limit on signup/edit forms. When a brother updates their photo, the old blob URL(s) are now deleted asynchronously to reduce duplicate/unused images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1427ff7991c37fd90cdad76fdab9489a05a3b0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->